### PR TITLE
fix: potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/backend/services/forwarder.py
+++ b/backend/services/forwarder.py
@@ -36,7 +36,7 @@ class EmailForwarder:
                             smtp_server = "smtp.mail.me.com"
                         elif hostname and hostname.startswith("imap."):
                             # Try guessing smtp.domain
-                            smtp_server = imap_s.replace("imap.", "smtp.", 1)
+                            smtp_server = hostname.replace("imap.", "smtp.", 1)
             except:
                 pass
 


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/4](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/4)

The right fix is to avoid using a substring check (`in`) for verifying the IMAP server's hostname. Instead, we should use proper URL parsing to extract the hostname and precisely compare it—either matching against the exact name or ensuring it ends with `.mail.me.com` or is exactly `mail.me.com`. In Python, we can use `urllib.parse.urlparse` to safely extract the network location (hostname) from a URL, or if the value is just a host string, manipulate and match it accordingly.

Specifically:
- For the `"mail.me.com" in imap_s` check, parse out the hostname. If the result is either exactly `"mail.me.com"` or ends with `".mail.me.com"`, proceed.
- Likewise, for the `"icloud" in imap_s` check, handle it in a similar fashion (though `"icloud"` is less likely to occur as a suffix, so substring may suffice, but for completeness, use a robust match).

Needed:
- Import `urlparse` from `urllib.parse`.
- Change relevant checks in lines 29-32 to parse host values and perform explicit matches.
- Ensure these imports and logic are only used within this file, as shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
