### PR TITLE
fix: potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,4 +1,7 @@
 name: "PR Title Check"
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/3](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/3)

To address the issue, we need to add a `permissions` block specifying the least privilege required for the workflow (ideally at the top level, to cover all jobs, unless individual jobs require different permissions). For this PR title validation workflow using `amannn/action-semantic-pull-request`, only limited read access to repository contents is required, and (in rare cases) write access for pull requests if it leaves comments or status checks. Based on the documentation for `amannn/action-semantic-pull-request`, only `pull-requests: write` and `contents: read` are required. 

The block

```yaml
permissions:
  contents: read
  pull-requests: write
```

should be placed at the root of the workflow YAML file, just below the `name:` declaration and before the `on:` block (for clear visibility and to apply to all jobs). No other code changes or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
