### PR TITLE
fix: potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/2](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/2)

To fix the problem, we should add an explicit `permissions` block to the workflow so that the GitHub Actions runner uses only the minimum necessary permissions. Since none of the jobs in this workflow appear to require write access to repository contents or pull requests, setting `permissions: contents: read` at the workflow root is sufficient and least-privileged. This change should be made at the top level (just after the workflow `name:` block), so that it applies to all jobs, unless otherwise overridden. No imports or methods are needed – just a simple YAML block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
