### PR TITLE
fix: potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/1](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/1)

To address the flagged issue, the solution is to add an explicit `permissions` block to the workflow YAML. Since neither job requires writing to the repository or any advanced GitHub API access, the least-privilege configuration is adequate. The recommended approach is to add a `permissions:` block at the top level of the workflow (after `name:` or after `on:`), which applies to all jobs unless overridden per job. Set `contents: read` as a minimal starting point. No further imports or dependencies are needed; simply insert the block immediately after the `name:` declaration or after the `on:` block for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
