### PR TITLE
fix: potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -17,7 +17,7 @@ class EmailService:
             mail.logout()
             return {"success": True, "error": None}
         except Exception as e:
-            logging.exception(f"Error when testing email connection for user '{email_user}'")
+            logging.exception("Error when testing email connection")
             return {"success": False, "error": "Unable to connect to email server"}
 
     @staticmethod


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/6](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/6)

To fix the information exposure, update the `EmailService.test_connection` method (in `backend/services/email_service.py`) so that, upon catching exceptions, it does **not** return the stringified exception to the caller. Instead, it should log the error for server-side debugging (using Python's `logging` module), and then return a generic error message such as `"Unable to connect to email server"`. No existing functionality needs to change—connection errors should still be represented and passed back to the client, but details must be generic.

Required changes:
- Import the `logging` library in `backend/services/email_service.py`.
- Use a logger to record the caught exception in the `except` block of `test_connection`.
- Update the value of the `"error"` field in the return value to a generic message, e.g. `"Unable to connect to email server"`.

Only `backend/services/email_service.py` requires modification. No changes to `backend/routers/settings.py` are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
