### PR TITLE
fix: potential fix for code scanning alert no. 7: Reflected server-side cross-site scripting

### DIFF
--- a/backend/routers/actions.py
+++ b/backend/routers/actions.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import os
 from datetime import datetime, timezone
-
+import html
 from backend.services.command_service import CommandService
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse
@@ -26,6 +26,9 @@ def quick_action(cmd: str, arg: str, ts: str, sig: str):
     """
     if not verify_signature(cmd, arg, ts, sig):
         raise HTTPException(status_code=403, detail="Invalid signature")
+
+    # Escape user input for safe HTML rendering
+    safe_arg = html.escape(arg)
 
     # Check timestamp expiration (e.g. 7 days link validity)
     try:
@@ -53,17 +56,17 @@ def quick_action(cmd: str, arg: str, ts: str, sig: str):
         # But for 'STOP amazon', it handles as blocked sender.
         # Ideally we differentiate STOP_SENDER vs STOP_CATEGORY in the link generation.
         success = True
-        message = f"🚫 Successfully Blocked: {arg}"
+        message = f"🚫 Successfully Blocked: {safe_arg}"
 
     elif cmd.upper() == "MORE":
         CommandService._add_preference(arg, "Always Forward")
         success = True
-        message = f"✅ Always Forwarding: {arg}"
+        message = f"✅ Always Forwarding: {safe_arg}"
 
     elif cmd.upper() == "BLOCK_CATEGORY":
         CommandService._add_preference(arg, "Blocked Category")
         success = True
-        message = f"🚫 Blocked Category: {arg}"
+        message = f"🚫 Blocked Category: {safe_arg}"
 
     elif cmd.upper() == "SETTINGS":
         from backend.database import engine


### PR DESCRIPTION
Potential fix for [https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/7](https://github.com/thef4tdaddy/SentinelShare/security/code-scanning/7)

To fix this vulnerability, ensure that any user-supplied data included in an HTML response is properly escaped. For Python 3.2+, use `html.escape()` to safely encode HTML special characters, so malicious input cannot break out of intended contexts or inject scripts. In the present code, `arg` (from the request) is used to construct `message`, and it is interpolated into the HTML response. To remediate, escape `arg` (and potentially `message`) before using it in any HTML construction in the return statement.

**Best method:**  
Import `html.escape` near the top of the file, and ensure that `arg` is escaped right after receiving it (e.g., `safe_arg = html.escape(arg)`). Use `safe_arg` when constructing messages or HTML outputs wherever `arg` content is returned to the browser—specifically:  
- Replace usages of `arg` inside HTML responses with the escaped version.
- Modify `message` assignments that use `{arg}` to reference the escaped user input, so the full value shown to the user is safe.
- Do not escape the entire `message` if it contains emoji or trusted template content; escape only the part that comes from the user.  
Make sure to add the required `import html` statement if not already present.

**Files/lines to change:**  
- Edit `backend/routers/actions.py`, add `import html`.
- In the `quick_action()` function, escape `arg` after capturing it and use its escaped version when building `message`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
